### PR TITLE
Improves type handling in stack pop operation

### DIFF
--- a/src/instruction/set.zig
+++ b/src/instruction/set.zig
@@ -119,9 +119,14 @@ pub const Instructions = struct {
                 null,
             );
         }
-
         vm.sp -= 1;
-        registers[dest] = vm.stack.pop();
+        const popped = vm.stack.pop();
+
+        if (@TypeOf(popped) == ?u32) {
+            registers[dest] = popped orelse unreachable;
+        } else {
+            registers[dest] = popped;
+        }
     }
 
     /// JMP - Unconditional jump


### PR DESCRIPTION
This pull request includes a change to the `src/instruction/set.zig` file to improve type safety when popping values from the stack. The most important change ensures that if the popped value is an optional `u32`, it correctly handles the `null` case using the `orelse` operator.

fixes #2 

Improvements to type safety:

* [`src/instruction/set.zig`](diffhunk://#diff-6a643ea8dc6344e4ce06ca866cef96bab6678a181129a40debccb92520bf6dccL122-R129): Modified the code to check the type of the popped value from the stack and handle the `null` case for optional `u32` values using the `orelse` operator.