### PR TITLE
Added logging and better error handling

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -35,6 +35,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
+    lib_unit_tests.root_module.addImport("nexlog", nexlog_dep.module("nexlog"));
     const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
 
     const test_step = b.step("test", "Run unit tests");

--- a/build.zig
+++ b/build.zig
@@ -13,10 +13,20 @@ pub fn build(b: *std.Build) void {
     });
     b.installArtifact(lib);
 
+    // setup logging
+    const nexlog_dep = b.dependency("nexlog", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    lib.root_module.addImport("nexlog", nexlog_dep.module("nexlog"));
+
     // Create module for use as a dependency
     const ziglet_module = b.addModule("ziglet", .{
         .root_source_file = b.path("src/root.zig"),
     });
+
+    ziglet_module.addImport("nexlog", nexlog_dep.module("nexlog"));
 
     // Unit tests
     const lib_unit_tests = b.addTest(.{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,12 @@
     .name = "Ziglet",
     .version = "0.0.0",
 
-    .dependencies = .{},
+    .dependencies = .{
+        .nexlog = .{
+            .url = "git+https://github.com/chrischtel/nexlog?ref=develop#5f1580052c4b310d353c792326f8f1340ad86a3a",
+            .hash = "1220c760f31f4e218e63c0d9a526d856c405195df90a448395184950704e9128610a",
+        },
+    },
 
     .paths = .{
         "build.zig",

--- a/examples/calculator.zig
+++ b/examples/calculator.zig
@@ -42,7 +42,9 @@ pub fn main() !void {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    var vm = try ziglet.VM.init(allocator);
+    var vm = try ziglet.VM.initWithConfig(allocator, .{
+        .debug_mode = true,
+    });
     defer vm.deinit();
 
     // Create and run program

--- a/examples/jump_instructions.zig
+++ b/examples/jump_instructions.zig
@@ -66,7 +66,6 @@ pub fn main() !void {
     defer allocator.free(program);
 
     try vm.loadProgram(program);
-    vm.setDebugMode(false);
 
     std.debug.print("\nStarting counter loop to {}\n", .{target});
     std.debug.print("Executing program...\n\n", .{});

--- a/examples/simple.zig
+++ b/examples/simple.zig
@@ -16,14 +16,6 @@ pub fn main() !void {
     defer args.deinit();
     _ = args.skip(); // Skip program name
 
-    // Enable debug mode if --debug flag is present
-    const debug_mode = if (args.next()) |arg|
-        std.mem.eql(u8, arg, "--debug")
-    else
-        false;
-
-    vm.setDebugMode(debug_mode);
-
     // Create and run program
     const program = &[_]ziglet.Instruction{
         .{ .opcode = .LOAD, .dest_reg = 1, .operand1 = 5, .operand2 = 0 },

--- a/src/core/vm.zig
+++ b/src/core/vm.zig
@@ -11,10 +11,29 @@ const Error = @import("../error.zig").Error;
 const createError = @import("../error.zig").createError;
 const instruction_types = @import("../instruction/types.zig");
 const decoder = @import("../instruction/decoder.zig");
+const nexlog = @import("nexlog");
 
 pub const Instruction = instruction_types.Instruction;
 pub const OpCode = instruction_types.OpCode;
 pub const REGISTER_COUNT = instruction_types.REGISTER_COUNT;
+
+pub const VMConfig = struct {
+    memory_size: usize = 1024 * 64, // 64KB default
+    debug_mode: bool = false,
+    log_config: LogConfig = .{},
+
+    pub const LogConfig = struct {
+        min_level: nexlog.LogLevel = .debug,
+        enable_colors: bool = true,
+        buffer_size: usize = 8192,
+        log_file_path: ?[]const u8 = "logs/vm.log",
+        max_file_size: usize = 5 * 1024 * 1024,
+        max_rotated_files: usize = 3,
+        enable_rotation: bool = true,
+        enable_async: bool = true,
+        enable_metadata: bool = true,
+    };
+};
 
 /// The Virtual Machine state
 pub const VM = struct {
@@ -44,6 +63,68 @@ pub const VM = struct {
     instruction_cache: std.AutoHashMap(usize, Instruction),
     /// Hot path detection
     execution_count: std.AutoHashMap(usize, usize),
+    /// Logger instance
+    logger: *nexlog.Logger,
+
+    /// Initialize a new VM with custom configuration
+    pub fn initWithConfig(
+        allocator: std.mem.Allocator,
+        config: VMConfig,
+    ) !*VM {
+        // Initialize logger first
+        try std.fs.cwd().makePath("logs");
+
+        var builder = nexlog.LogBuilder.init();
+        _ = builder.setMinLevel(config.log_config.min_level)
+            .enableColors(config.log_config.enable_colors)
+            .setBufferSize(config.log_config.buffer_size)
+            .enableMetadata(config.log_config.enable_metadata);
+
+        if (config.log_config.log_file_path) |path| {
+            _ = builder.enableFileLogging(true, path)
+                .setMaxFileSize(config.log_config.max_file_size)
+                .setMaxRotatedFiles(config.log_config.max_rotated_files)
+                .enableRotation(config.log_config.enable_rotation);
+        }
+
+        if (config.log_config.enable_async) {
+            _ = builder.enableAsyncMode(true);
+        }
+
+        try builder.build(allocator);
+
+        const logger = nexlog.getDefaultLogger() orelse return error.LoggerNotInitialized;
+
+        // Initialize VM memory
+        const memory = try allocator.alloc(u8, config.memory_size);
+
+        // Initialize hashmaps for optimization
+        const instruction_cache = std.AutoHashMap(usize, Instruction).init(allocator);
+        const execution_count = std.AutoHashMap(usize, usize).init(allocator);
+
+        const vm = try allocator.create(VM);
+        vm.* = VM{
+            .registers = [_]u32{0} ** REGISTER_COUNT,
+            .pc = 0,
+            .program = &[_]Instruction{},
+            .allocator = allocator,
+            .running = false,
+            .stack = std.ArrayList(u32).init(allocator),
+            .sp = 0,
+            .cmp_flag = 0,
+            .memory = memory,
+            .memory_size = config.memory_size,
+            .debug_mode = config.debug_mode,
+            .instruction_cache = instruction_cache,
+            .execution_count = execution_count,
+            .logger = logger,
+        };
+
+        const metadata = vm.createLogMetadata();
+        vm.logger.info("VM initialized with {d}KB memory", .{config.memory_size / 1024}, metadata);
+
+        return vm;
+    }
 
     pub fn optimizeHotPaths(self: *VM) !void {
         // Identify frequently executed code paths
@@ -61,6 +142,9 @@ pub const VM = struct {
         instruction_count: usize,
         last_instruction: ?Instruction,
         stack_depth: usize,
+        registers: [REGISTER_COUNT]u32,
+        pc: usize,
+        cmp_flag: i8,
 
         pub fn format(
             self: DebugInfo,
@@ -69,68 +153,99 @@ pub const VM = struct {
             writer: anytype,
         ) !void {
             try writer.print(
-                "Instructions executed: {}\n" ++
-                    "Stack depth: {}\n",
-                .{
-                    self.instruction_count,
-                    self.stack_depth,
-                },
-            );
+                \\Debug Information:
+                \\  Instructions executed: {}
+                \\  Stack depth: {}
+                \\  Program Counter: {}
+                \\  Compare Flag: {}
+                \\
+                \\Registers:
+                \\
+            , .{
+                self.instruction_count,
+                self.stack_depth,
+                self.pc,
+                self.cmp_flag,
+            });
+
+            // Print registers in a formatted way
+            for (self.registers, 0..) |reg, i| {
+                if (reg != 0) {
+                    try writer.print("  R{d}: {d}\n", .{ i, reg });
+                }
+            }
 
             if (self.last_instruction) |inst| {
-                try writer.print("Last instruction: {}\n", .{inst});
+                try writer.print("\nLast instruction: {}\n", .{inst});
             }
         }
     };
 
     pub fn getDebugInfo(self: *VM) DebugInfo {
-        return .{
+        const metadata = self.createLogMetadata();
+        self.logger.debug("Gathering debug information", .{}, metadata);
+
+        const debug_info = DebugInfo{
             .instruction_count = self.pc,
             .last_instruction = if (self.pc > 0) self.program[self.pc - 1] else null,
             .stack_depth = self.stack.items.len,
+            .registers = self.registers,
+            .pc = self.pc,
+            .cmp_flag = self.cmp_flag,
         };
+
+        // Log detailed debug information
+        self.logger.debug(
+            \\Debug snapshot:
+            \\  PC: {d}
+            \\  Stack depth: {d}
+            \\  Instructions executed: {d}
+            \\
+        , .{
+            debug_info.pc,
+            debug_info.stack_depth,
+            debug_info.instruction_count,
+        }, metadata);
+
+        return debug_info;
     }
-    /// Initialize a new VM
-    /// Initialize a new VM
+
+    /// Initialize a new VM with default configuration
     pub fn init(allocator: std.mem.Allocator) !*VM {
-        const default_memory_size = 1024 * 64; // 64KB
-        const memory = try allocator.alloc(u8, default_memory_size);
-
-        // Initialize hashmaps for optimization
-        const instruction_cache = std.AutoHashMap(usize, Instruction).init(allocator);
-        const execution_count = std.AutoHashMap(usize, usize).init(allocator);
-
-        const vm = try allocator.create(VM);
-        vm.* = VM{
-            .registers = [_]u32{0} ** REGISTER_COUNT,
-            .pc = 0,
-            .program = &[_]Instruction{},
-            .allocator = allocator,
-            .running = false,
-            .stack = std.ArrayList(u32).init(allocator),
-            .sp = 0,
-            .cmp_flag = 0,
-            .memory = memory,
-            .memory_size = default_memory_size,
-            .debug_mode = false,
-            .instruction_cache = instruction_cache,
-            .execution_count = execution_count,
-        };
-        return vm;
+        return initWithConfig(allocator, .{});
     }
+
+    fn createLogMetadata(self: *const VM) nexlog.LogMetadata {
+        _ = self;
+        return .{
+            .timestamp = std.time.timestamp(),
+            .thread_id = 0, // In a real app, get actual thread ID
+            .file = @src().file,
+            .line = @src().line,
+            .function = @src().fn_name,
+        };
+    }
+
     /// Enable or disable debug mode
     pub fn setDebugMode(self: *VM, enable: bool) void {
         self.debug_mode = enable;
     }
-    /// Clean up VM resources
+
     pub fn deinit(self: *VM) void {
+        const metadata = self.createLogMetadata();
+        self.logger.info("VM shutting down", .{}, metadata);
+
         self.allocator.free(self.memory);
         self.stack.deinit();
         self.instruction_cache.deinit();
         self.execution_count.deinit();
+
+        // Ensure all logs are flushed before shutdown
+        self.logger.flush() catch {};
+
+        nexlog.deinit(); // Clean up the logger
         self.allocator.destroy(self);
     }
-
     /// Load a program into the VM
     pub fn loadProgram(self: *VM, program: []const Instruction) !void {
         if (program.len == 0) {
@@ -148,7 +263,10 @@ pub const VM = struct {
 
     /// Execute the loaded program
     pub fn execute(self: *VM) !void {
+        const metadata = self.createLogMetadata();
+
         if (self.program.len == 0) {
+            self.logger.err("Attempted to execute with no program loaded", .{}, metadata);
             return createError(
                 error.InvalidInstruction,
                 "executing program",
@@ -158,14 +276,17 @@ pub const VM = struct {
             );
         }
 
-        if (self.debug_mode) {
-            std.debug.print("Executing program with {} instructions\n", .{self.program.len});
-        }
+        self.logger.info("Starting program execution with {d} instructions", .{self.program.len}, metadata);
 
         self.running = true;
         while (self.running and self.pc < self.program.len) {
             if (self.debug_mode) {
-                std.debug.print("Executing instruction at PC={}: {}\n", .{ self.pc, self.program[self.pc] });
+                const current_inst = self.program[self.pc];
+                self.logger.debug(
+                    "Executing instruction at PC={d}: {any}",
+                    .{ self.pc, current_inst },
+                    metadata,
+                );
             }
 
             try self.execution_count.put(self.pc, (self.execution_count.get(self.pc) orelse 0) + 1);
@@ -174,23 +295,60 @@ pub const VM = struct {
             self.pc += 1;
 
             if (self.pc % 1000 == 0) {
+                self.logger.debug("Optimizing hot paths at PC={d}", .{self.pc}, metadata);
                 try self.optimizeHotPaths();
             }
         }
 
-        // Print debug info at the end if in debug mode
+        // Log final execution state
         if (self.debug_mode) {
-            std.debug.print("\nDebug Info:\n{}", .{self.getDebugInfo()});
+            const debug_info = self.getDebugInfo();
+            self.logger.debug(
+                \\Execution completed:
+                \\{}
+            ,
+                .{debug_info},
+                metadata,
+            );
         }
+
+        self.logger.info("Program execution completed successfully", .{}, metadata);
     }
 
-    /// Execute a single instruction
     fn executeInstruction(self: *VM, inst: instruction_types.Instruction) !void {
+        const metadata = self.createLogMetadata();
+
         if (inst.opcode == .HALT) {
+            self.logger.debug("Executing HALT instruction", .{}, metadata);
             self.running = false;
             return;
         }
+
+        if (self.debug_mode) {
+            // Log register state before execution
+            self.logger.debug(
+                "Before instruction {any}: R{d}={d}, R{d}={d}",
+                .{
+                    inst,
+                    inst.operand1,
+                    self.registers[inst.operand1],
+                    inst.operand2,
+                    self.registers[inst.operand2],
+                },
+                metadata,
+            );
+        }
+
         try decoder.decode(inst, self);
+
+        if (self.debug_mode) {
+            // Log register state after execution
+            self.logger.debug(
+                "After instruction: R{d}={d}",
+                .{ inst.dest_reg, self.registers[inst.dest_reg] },
+                metadata,
+            );
+        }
     }
 
     /// Get the value of a register

--- a/src/error.zig
+++ b/src/error.zig
@@ -1,107 +1,40 @@
 //! Error handling system for Ziglet VM
-//!
-//! This module provides a comprehensive error handling system that helps users
-//! diagnose and fix issues when using the Ziglet VM. It includes detailed error
-//! contexts, locations, and actionable suggestions.
-//!
-//! Example:
-//! ```zig
-//! const ziglet = @import("ziglet");
-//!
-//! fn main() !void {
-//!     var vm = try ziglet.VM.init(allocator);
-//!     vm.execute() catch |err| {
-//!         // Prints detailed error information with context
-//!         std.debug.print("{}\n", .{err});
-//!         return err;
-//!     };
-//! }
-//! ```
-
+//! Provides detailed error context and unified logging for errors.
 const std = @import("std");
+const nexlog = @import("nexlog");
 
 /// Provides detailed context about an error that occurred during VM operation.
-/// This structure ensures that users receive comprehensive information about
-/// what went wrong and how to fix it.
 pub const ErrorContext = struct {
-    /// The specific operation or action that was being performed when the error occurred.
-    /// This helps users understand what the VM was trying to do.
-    /// Example: "executing ADD instruction" or "allocating memory for stack"
+    /// The operation that was being performed when the error occurred.
     operation: []const u8,
-
-    /// The precise location where the error occurred in the user's code or script.
-    /// This field is optional as not all errors have a specific location.
-    /// For example, initialization errors might not have a location.
+    /// Location information (optional).
     location: ?Location = null,
-
-    /// Detailed explanation of what specifically went wrong during the operation.
-    /// This should provide specific information about the error condition.
-    /// Example: "Register R15 does not exist" or "Stack size exceeded 1MB limit"
+    /// Explanation of what went wrong.
     details: []const u8,
-
-    /// Actionable suggestion on how to fix or avoid the error.
-    /// This should provide clear, concrete steps that users can take.
-    /// Example: "Use registers R0 through R14 only" or "Increase stack size in VM configuration"
+    /// Suggestion how to fix the error.
     suggestion: []const u8,
 
-    /// Represents a specific location in code where an error occurred.
-    /// This helps users quickly find and fix issues in their code.
     pub const Location = struct {
-        /// Line number in the source code or script (1-based)
+        /// 1-based line number.
         line: usize,
-        /// Column number in the source code or script (1-based)
+        /// 1-based column number.
         column: usize,
-        /// Optional source file name or identifier
-        /// This might be null for REPL or dynamically generated code
+        /// Optional source file reference.
         file: ?[]const u8 = null,
     };
 };
 
-/// Comprehensive set of all possible errors that can occur during VM operation.
-/// Each error type is categorized and documented to help users understand
-/// and handle specific error cases.
+/// A comprehensive list of errors.
 pub const VMError = error{
-    // Memory-related errors
-    /// Indicates that the VM could not allocate required memory
-    /// This might occur during initialization or during operation
     OutOfMemory,
-
-    /// Attempted to access memory outside of allowed bounds
-    /// This often indicates a bug in user code or script
     MemoryAccessViolation,
-
-    /// Stack space has been exhausted
-    /// This might indicate infinite recursion or too deep call nesting
     StackOverflow,
-
-    // Instruction-related errors
-    /// Encountered an invalid or malformed instruction
-    /// This might indicate corrupted bytecode or a compilation error
     InvalidInstruction,
-
-    /// Attempted to use an operation not supported by the current VM configuration
-    /// This might occur when using extended instructions that aren't enabled
     UnsupportedOperation,
-
-    // Runtime-related errors
-    /// Attempted to divide by zero
-    /// This is a runtime arithmetic error that should be handled by user code
     DivisionByZero,
-
-    /// Operand types don't match the operation requirements
-    /// Example: Trying to add a string to a number
     TypeMismatch,
-
-    // Resource-related errors
-    /// A limited resource (other than memory) has been exhausted
-    /// Example: Too many open files or network connections
     ResourceExhausted,
-
-    // Configuration-related errors
-    /// VM configuration contains invalid or incompatible settings
-    /// This occurs during VM initialization with invalid configuration
     InvalidConfiguration,
-
     StackUnderflow,
     InvalidFunctionCall,
     InvalidMemoryAccess,
@@ -110,30 +43,18 @@ pub const VMError = error{
 };
 
 pub const SecurityConfig = struct {
-    /// Maximum allowed memory access
     max_memory: usize,
-    /// Maximum allowed stack depth
     max_stack_depth: usize,
-    /// Maximum instructions per execution
     max_instructions: usize,
-    /// Allow self-modifying code
     allow_self_modify: bool,
 };
 
-/// Combines an error with its detailed context to provide comprehensive
-/// error information and formatting capabilities.
+/// Combined error type with context.
 pub const Error = struct {
-    /// The specific error that occurred
     err: VMError,
-    /// Detailed context about the error
     context: ErrorContext,
 
-    /// Formats the error and its context into a human-readable message
-    /// This method is called automatically when formatting the error with
-    /// std.fmt.format() or printing it.
-    ///
-    /// Format options and fmt string are currently ignored as there is
-    /// only one formatting style.
+    /// Formats the error for printing.
     pub fn format(
         self: Error,
         comptime fmt: []const u8,
@@ -142,93 +63,45 @@ pub const Error = struct {
     ) !void {
         _ = fmt;
         _ = options;
-
-        // Write error header with the error type
         try writer.print("\nError: {s}\n", .{@errorName(self.err)});
-
-        // Write the operation that was being performed
         try writer.print("During: {s}\n", .{self.context.operation});
-
-        // Write location information if available
         if (self.context.location) |loc| {
             if (loc.file) |file| {
                 try writer.print("In file: {s}\n", .{file});
             }
             try writer.print("At line {d}, column {d}\n", .{ loc.line, loc.column });
         }
-
-        // Write detailed error description
         try writer.print("\nDetails: {s}\n", .{self.context.details});
-
-        // Write suggestion for fixing the error
-        try writer.print("\nSuggestion: {s}\n", .{self.context.suggestion});
+        try writer.print("Suggestion: {s}\n\n", .{self.context.suggestion});
     }
 };
 
-/// Creates a new Error with full context.
-/// This is the preferred way to create errors as it ensures all required
-/// context information is provided.
-///
-/// Parameters:
-///   - err: The specific VMError that occurred
-///   - operation: Description of the operation being performed
-///   - details: Detailed description of what went wrong
-///   - suggestion: Actionable suggestion for fixing the error
-///   - location: Optional location where the error occurred
-///
-/// Example:
-/// ```zig
-/// return createError(
-///     .InvalidInstruction,
-///     "executing ADD instruction",
-///     "Register R15 does not exist",
-///     "Use registers R0 through R14 only",
-///     .{
-///         .line = 42,
-///         .column = 10,
-///         .file = "script.zig",
-///     },
-/// );
-/// ```
-pub fn createError(
-    comptime err: VMError,
+/// Helper to generate consistent metadata for logging.
+fn createErrorMetadata() nexlog.LogMetadata {
+    return .{
+        .timestamp = std.time.timestamp(),
+        .thread_id = 0,
+        .file = @src().file,
+        .line = @src().line,
+        .function = @src().fn_name,
+    };
+}
+
+/// Runtime version of error creation. This function logs the error once,
+/// using the provided information, and returns the error.
+pub fn createRuntimeError(
+    err: VMError,
     operation: []const u8,
     details: []const u8,
     suggestion: []const u8,
-    location: ?ErrorContext.Location,
 ) VMError {
-    // Print error information
-    std.debug.print("\nError: {s}\n", .{@errorName(err)});
-    std.debug.print("During: {s}\n", .{operation});
+    const logger = nexlog.getDefaultLogger() orelse return err;
+    const metadata = createErrorMetadata();
 
-    // Print location if available
-    if (location) |loc| {
-        if (loc.file) |file| {
-            std.debug.print("In file: {s}\n", .{file});
-        }
-        std.debug.print("At line {d}, column {d}\n", .{ loc.line, loc.column });
-    }
-
-    std.debug.print("Details: {s}\n", .{details});
-    std.debug.print("Suggestion: {s}\n", .{suggestion});
-
-    return err;
-}
-
-test "error formatting" {
-    const err = createError(
-        error.InvalidInstruction,
-        "test operation",
-        "test details",
-        "test suggestion",
-        .{
-            .line = 1,
-            .column = 1,
-            .file = "test.zig",
-        },
+    logger.err(
+        "Error: {s}\nDuring: {s}\nDetails: {s}\nSuggestion: {s}\n",
+        .{ @errorName(err), operation, details, suggestion },
+        metadata,
     );
-
-    var buf: [1024]u8 = undefined;
-    var fbs = std.io.fixedBufferStream(&buf);
-    try std.fmt.format(fbs.writer(), "{}", .{err});
+    return err;
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -14,7 +14,7 @@ const instruction_set = @import("instruction/set.zig");
 pub const VM = vm_mod.VM;
 pub const Error = error_mod.Error;
 pub const VMError = error_mod.VMError;
-pub const createError = error_mod.createError;
+pub const createRuntimeError = error_mod.createRuntimeError;
 
 pub const Instruction = instruction_types.Instruction;
 pub const OpCode = instruction_types.OpCode;


### PR DESCRIPTION
This pull request focuses on integrating my`nexlog` logging library into the Ziglet VM, enhancing the VM's logging capabilities, and refining error handling. The most important changes include setting up the `nexlog` dependency, updating the VM initialization to support logging configurations, and removing the old debug mode in favor of comprehensive logging.

### Logging Integration:
* [`build.zig`](diffhunk://#diff-f87bb3596894756629bc39d595fb18d479dc4edf168d93a911cadcb060f10fccR16-R38): Added dependencies and imports for `nexlog` to enable logging throughout the VM.
* [`build.zig.zon`](diffhunk://#diff-12dc677c49af0bd162081512eac1adca6ec6040095aeaaa59cb9f931abccefc9L5-R10): Updated to include `nexlog` as a dependency.

### VM Initialization and Configuration:
* [`src/core/vm.zig`](diffhunk://#diff-4eccd5996a6983206c412bd8934435266853a91c48df592cbdc0160f7e46c455L3-L102): Introduced `VMConfig` struct to allow custom configurations, including logging settings. Updated VM initialization to use this configuration and set up the logger accordingly. [[1]](diffhunk://#diff-4eccd5996a6983206c412bd8934435266853a91c48df592cbdc0160f7e46c455L3-L102) [[2]](diffhunk://#diff-4eccd5996a6983206c412bd8934435266853a91c48df592cbdc0160f7e46c455L114-L221)

### Debug Mode Removal:
* `examples/calculator.zig`, `examples/jump_instructions.zig`, `examples/simple.zig`: Removed old debug mode code, reflecting the shift to using `nexlog` for logging. [[1]](diffhunk://#diff-7f15bf907e6a6cdae48ea840035598e4694bcd285c43c9400de164101eaa7ef3L45-R47) [[2]](diffhunk://#diff-e0ee76eb844f257696b401275080524eee5441bd4c9b04fc20df5e96af61408aL69) [[3]](diffhunk://#diff-9ff3cc251bd970c50166740f80ad75f793de9093fdee0c91eef30fdbbb897bceL19-L26)

### Error Handling Enhancements:
* [`src/error.zig`](diffhunk://#diff-31ebad738598504e01f7313f21e76c7eb1c128f9cc636dca0fa8957b7ec15748L2-L104): Simplified error handling structures and integrated logging for errors, providing detailed error context and unified logging. [[1]](diffhunk://#diff-31ebad738598504e01f7313f21e76c7eb1c128f9cc636dca0fa8957b7ec15748L2-L104) [[2]](diffhunk://#diff-31ebad738598504e01f7313f21e76c7eb1c128f9cc636dca0fa8957b7ec15748L113-R57)