### PR TITLE
Update build.zig, build.zig.zon, and fib.zig for Zig 0.15

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,11 +2,10 @@
     .name = .ziglet,
     .fingerprint = 0x27874d01c1f96faf,
     .version = "0.0.0",
-
     .dependencies = .{
         .nexlog = .{
-            .url = "git+https://github.com/chrischtel/nexlog?ref=develop#28f0d766be55f922f0e4d340a8c14cf6c10c2f08",
-            .hash = "1220ea04de9ed19f6a8f8b9cfac277c8ab4e46ffdc7d9affe83d649159ff5143c669",
+            .url = "git+https://github.com/chrischtel/nexlog.git#34f96f867315b28c93869c1eb379732b6556563b",
+            .hash = "nexlog-0.7.1-zfPDxMODAgCNyxp4x3xPp2V8Dx4mJ38GYHv4943DuNtu",
         },
     },
 

--- a/examples/fib.zig
+++ b/examples/fib.zig
@@ -88,7 +88,10 @@ fn createFibProgram(
 }
 
 pub fn main() !void {
-    const stdout = std.io.getStdOut().writer();
+    var stdout_buffer: [256]u8 = undefined;
+    var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
+    const stdout = &stdout_writer.interface;
+    
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
@@ -102,4 +105,5 @@ pub fn main() !void {
     try vm.execute();
     const result = try vm.getRegister(3);
     try stdout.print("fib({d}) = {d}\n", .{ n, result });
+    try stdout.flush();
 }


### PR DESCRIPTION
I updated build.zig to be compatible with Zig 0.15.2. I updated build.zig.zon to pull in the correct version of nexlog. Also, I updated the examples/fib.zig to use the new writer interface. 